### PR TITLE
Fix range slider synchronization bug

### DIFF
--- a/js/range.js
+++ b/js/range.js
@@ -30,9 +30,12 @@
 					number2 = parseFloat(numberS[1].value);
 			
       if (number1 > number2) {
+        // keep both the numeric variables and inputs in sync
         var tmp = number1;
-        numberS[0].value = number2;
-        numberS[1].value = tmp;
+        number1 = number2;
+        number2 = tmp;
+        numberS[0].value = number1;
+        numberS[1].value = number2;
       }
 
       rangeS[0].value = number1;


### PR DESCRIPTION
## Summary
- fix number swap logic in `range.js` so the numeric fields and range values stay in sync

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f50ca6afc83279c85377a873ba359