### PR TITLE
Add HTML validation setup

### DIFF
--- a/.github/workflows/htmlhint.yml
+++ b/.github/workflows/htmlhint.yml
@@ -1,0 +1,19 @@
+name: HTML Validation
+
+on:
+  pull_request:
+    paths:
+      - '**/*.html'
+      - 'package.json'
+      - '.github/workflows/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - run: npm install
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Estudia en Canada
+
+## HTML Validation
+
+To validate the HTML files with [HTMLHint](https://htmlhint.com/), first install the project dependencies and then run the test script:
+
+```bash
+npm install
+npm test
+```
+
+This will check all `.html` files in the repository for common issues.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "estudiaencanadaose.github.io",
+  "version": "1.0.0",
+  "description": "",
+  "main": "form-submission-handler.js",
+  "scripts": {
+    "test": "htmlhint \"**/*.html\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "htmlhint": "^1.1.4"
+  }
+}


### PR DESCRIPTION
## Summary
- configure npm with HTMLHint
- add README section for HTML validation
- run HTMLHint in GitHub Actions workflow

## Testing
- `npm test` *(fails: htmlhint not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f532e09488327a91f5f7f53e187e9